### PR TITLE
Issue 3/Add parametrized testing examples

### DIFF
--- a/tests/fizzbuzz/fizzbuzz.ipynb
+++ b/tests/fizzbuzz/fizzbuzz.ipynb
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* Condensed version of the function"
+    "* Condensed version"
    ]
   },
   {
@@ -165,25 +165,6 @@
    "outputs": [],
    "source": [
     "fizzbuzz_b(\"Some string\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Parametrization"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "* You can have multiple parametrizations for a test function.\n",
-    "    * can have multiple `@pytest.mark.para,etrize()` decorators\n",
-    "    * can parametrize multiple `fixtures` per test\n",
-    "    * can use `pytest_generate_tests()` to parametrize multiple parameters\n",
-    "    * can use a combination of techniques\n",
-    "    * can blow up into lots and lots of test cases very fast"
    ]
   },
   {

--- a/tests/fizzbuzz/test_fizzbuzz_01_without_parametrization.py
+++ b/tests/fizzbuzz/test_fizzbuzz_01_without_parametrization.py
@@ -1,0 +1,19 @@
+# test_fizzbuzz_01_without_parametrization
+
+from fizzbuzz import fizzbuzz
+
+
+def test_fizz():
+    assert fizzbuzz(3) == "Fizz"
+
+
+def test_buzz():
+    assert fizzbuzz(5) == "Buzz"
+
+
+def test_fizzbuzz():
+    assert fizzbuzz(0) == "FizzBuzz"
+
+
+def test_invalid():
+    assert fizzbuzz("Zero") == None

--- a/tests/fizzbuzz/test_fizzbuzz_02_dont_do_this.py
+++ b/tests/fizzbuzz/test_fizzbuzz_02_dont_do_this.py
@@ -1,4 +1,4 @@
-# test_fizzbuzz_02_dont_do_thi
+# test_fizzbuzz_02_dont_do_this
 
 from fizzbuzz import fizzbuzz
 

--- a/tests/fizzbuzz/test_fizzbuzz_02_dont_do_this.py
+++ b/tests/fizzbuzz/test_fizzbuzz_02_dont_do_this.py
@@ -1,0 +1,18 @@
+# test_fizzbuzz_02_dont_do_thi
+
+from fizzbuzz import fizzbuzz
+
+
+# Don't do this!
+def test_fizzbuzz():
+    FIZZBUZZ_TEST_CASES = [
+        (3, "Fizz"),
+        (5, "Buzz"),
+        (7, "7"),
+        (15, "FizzBuzz"),
+        (100, "Buzz"),
+        (0, "FizzBuzz"),
+        (-3, "Fizz"),
+    ]
+    for value, expected in FIZZBUZZ_TEST_CASES:
+        assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_03_function_parametrization.py
+++ b/tests/fizzbuzz/test_fizzbuzz_03_function_parametrization.py
@@ -1,0 +1,21 @@
+# test_fizzbuzz_03_function_parametrization
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (3, "Fizz"),
+        (5, "Buzz"),
+        (7, "7"),
+        (15, "FizzBuzz"),
+        (100, "Buzz"),
+        (0, "FizzBuzz"),
+        (-3, "Fizz"),
+    ],
+)
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_04_parameters_from_named_list.py
+++ b/tests/fizzbuzz/test_fizzbuzz_04_parameters_from_named_list.py
@@ -1,0 +1,20 @@
+# test_fizzbuzz_04_parameters_from_named_list
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    (7, "7"),
+    (15, "FizzBuzz"),
+    (100, "Buzz"),
+    (0, "FizzBuzz"),
+    (-3, "Fizz"),
+]
+
+
+@pytest.mark.parametrize("value, expected", FIZZ_BUZZ_TEST_CASES)
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_05_parameters_from_function.py
+++ b/tests/fizzbuzz/test_fizzbuzz_05_parameters_from_function.py
@@ -1,0 +1,22 @@
+# test_fizzbuzz_05_parameters_from_function
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+
+def fizzbuzz_cases():
+    return [
+        (3, "Fizz"),
+        (5, "Buzz"),
+        (7, "7"),
+        (15, "FizzBuzz"),
+        (100, "Buzz"),
+        (0, "FizzBuzz"),
+        (-3, "Fizz"),
+    ]
+
+
+@pytest.mark.parametrize("value, expected", fizzbuzz_cases())
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_06_parameters_from_generator.py
+++ b/tests/fizzbuzz/test_fizzbuzz_06_parameters_from_generator.py
@@ -1,0 +1,23 @@
+# test_fizzbuzz_06_parameters_from_generator
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+
+def fizzbuzz_cases():
+    for f in [
+        (3, "Fizz"),
+        (5, "Buzz"),
+        (7, "7"),
+        (15, "FizzBuzz"),
+        (100, "Buzz"),
+        (0, "FizzBuzz"),
+        (-3, "Fizz"),
+    ]:
+        yield f
+
+
+@pytest.mark.parametrize("value, expected", fizzbuzz_cases())
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_07_parameters_from_a_file.py
+++ b/tests/fizzbuzz/test_fizzbuzz_07_parameters_from_a_file.py
@@ -1,0 +1,20 @@
+# test_fizzbuzz_07_parameters_from_a_file
+
+import csv
+import pytest
+from pathlib import Path
+
+from fizzbuzz import fizzbuzz
+
+p = Path.cwd()
+FIZZBUZZ_DATA_FILE_NAME = p / "tests" / "fizzbuzz" / "fizzbuzz_data.csv"
+
+
+def fizzbuzz_cases():
+    with open(FIZZBUZZ_DATA_FILE_NAME) as csvfile:
+        for value, expected in csv.reader(csvfile):
+            yield (int(value), expected)
+
+@pytest.mark.parametrize("value, expected", fizzbuzz_cases())
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_08_fixture.py
+++ b/tests/fizzbuzz/test_fizzbuzz_08_fixture.py
@@ -1,0 +1,25 @@
+# test_fizzbuzz_08_fixture.py
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    (7, "7"),
+    (15, "FizzBuzz"),
+    (100, "Buzz"),
+    (0, "FizzBuzz"),
+    (-3, "Fizz"),
+]
+
+
+@pytest.fixture(params=FIZZ_BUZZ_TEST_CASES)
+def a_case(request):
+    return request.param
+
+
+def test_fix(a_case):
+    value, expected = a_case
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_09_ids_list.py
+++ b/tests/fizzbuzz/test_fizzbuzz_09_ids_list.py
@@ -1,0 +1,26 @@
+# test_fizzbuzz_09_ids_list.py
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    (7, "7"),
+    (15, "FizzBuzz"),
+    (100, "Buzz"),
+    (0, "FizzBuzz"),
+    (-3, "Fizz"),
+]
+
+
+@pytest.fixture(params=FIZZ_BUZZ_TEST_CASES,
+                ids=[3, 5, 7, 15, 100, 0, -3])
+def a_case(request):
+    return request.param
+
+
+def test_fix(a_case):
+    value, expected = a_case
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_10_ids_function.py
+++ b/tests/fizzbuzz/test_fizzbuzz_10_ids_function.py
@@ -1,0 +1,26 @@
+# test_fizzbuzz_10_ids_function.py
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    (7, "7"),
+    (15, "FizzBuzz"),
+    (100, "Buzz"),
+    (0, "FizzBuzz"),
+    (-3, "Fizz"),
+]
+
+
+@pytest.fixture(params=FIZZ_BUZZ_TEST_CASES,
+        ids=str)  # or repr, or lambda t:t[3]
+def a_case(request):
+    return request.param
+
+
+def test_fix(a_case):
+    value, expected = a_case
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_11_custom_ids_function.py
+++ b/tests/fizzbuzz/test_fizzbuzz_11_custom_ids_function.py
@@ -1,0 +1,30 @@
+# test_fizzbuzz_11_custom_ids_function.py
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    (7, "7"),
+    (15, "FizzBuzz"),
+    (100, "Buzz"),
+    (0, "FizzBuzz"),
+    (-3, "Fizz"),
+]
+
+
+def idfn(a_case):
+    value, expected = a_case
+    return f"{value}-{expected}"
+
+
+@pytest.fixture(params=FIZZ_BUZZ_TEST_CASES, ids=idfn)
+def a_case(request):
+    return request.param
+
+
+def test_fix(a_case):
+    value, expected = a_case
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_12_pytest_generate_tests.py
+++ b/tests/fizzbuzz/test_fizzbuzz_12_pytest_generate_tests.py
@@ -1,0 +1,32 @@
+# test_fizzbuzz_12_pytest_generate_tests.py
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    (7, "7"),
+    (15, "FizzBuzz"),
+    (100, "Buzz"),
+    (0, "FizzBuzz"),
+    (-3, "Fizz"),
+]
+
+
+def idfn(a_case):
+    value, expected = a_case
+    return f"{value}-{expected}"
+
+
+def pytest_generate_tests(metafunc):
+    if "gen_case" in metafunc.fixturenames:
+        metafunc.parametrize("gen_case",
+                             FIZZ_BUZZ_TEST_CASES,
+                             ids=idfn)
+
+
+def test_gen(gen_case):
+    value, expected = gen_case
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_13_test_param_smoke.py
+++ b/tests/fizzbuzz/test_fizzbuzz_13_test_param_smoke.py
@@ -1,0 +1,22 @@
+# test_fizzbuzz_13_test_param_smoke.py
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+smoke = pytest.mark.smoke
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    pytest.param(7, "7", id='7'),
+    (15, "FizzBuzz"),
+    pytest.param(100, "Buzz", marks=smoke),
+    pytest.param(0, "FizzBuzz", marks=smoke),
+    pytest.param(-3, "Fizz", marks=smoke),
+]
+
+
+@pytest.mark.parametrize("value, expected", FIZZ_BUZZ_TEST_CASES)
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_14_indirect_parameter.py
+++ b/tests/fizzbuzz/test_fizzbuzz_14_indirect_parameter.py
@@ -1,0 +1,28 @@
+# test_fizzbuzz_14_indirect_parameter.py
+
+import pytest
+
+from fizzbuzz import fizzbuzz
+
+FIZZ_BUZZ_TEST_CASES = [
+    (3, "Fizz"),
+    (5, "Buzz"),
+    (7, "7"),
+    (15, "FizzBuzz"),
+    (100, "Buzz"),
+    (0, "FizzBuzz"),
+    (-3, "Fizz"),
+]
+
+
+@pytest.fixture()
+def expected(request):
+    if request.param == "FizzBuzz":
+        print("\nthis is one of the FizzBuzz test cases")
+    return request.param
+
+
+@pytest.mark.parametrize("value, expected", FIZZ_BUZZ_TEST_CASES,
+                          indirect=["expected"])
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected

--- a/tests/fizzbuzz/test_fizzbuzz_15_indirect_example.py
+++ b/tests/fizzbuzz/test_fizzbuzz_15_indirect_example.py
@@ -1,0 +1,27 @@
+# test_fizzbuzz_15_indirect_example.py
+
+import csv
+import pytest
+from pathlib import Path
+
+from fizzbuzz import fizzbuzz
+
+p = Path.cwd()
+FIZZBUZZ_DATA_FILE_NAME = p / "tests" / "fizzbuzz" / "fizzbuzz_data.csv"
+
+
+def fizzbuzz_cases():
+    with open(FIZZBUZZ_DATA_FILE_NAME) as csvfile:
+        for value, expected in csv.reader(csvfile):
+            yield (value, expected)
+
+
+@pytest.fixture()
+def value(request):
+    return int(request.param)
+
+
+@pytest.mark.parametrize("value, expected", fizzbuzz_cases(),
+                         indirect=["value"])
+def test_fizzbuzz(value, expected):
+    assert fizzbuzz(value) == expected


### PR DESCRIPTION
Add parametrized testing examples:
- without_parametrization
- dont_do_this
- function_parametrization
- parameters_from_named_list
- parameters_from_function
- parameters_from_generator
- parameters_from_a_file
- fixture
- ids_list
- ids_function
- custom_ids_function
- pytest_generate_tests
- test_param_smoke
- indirect_parameter
- indirect_example