### PR TITLE
Issue 18/Add packaging

### DIFF
--- a/fizzbuzz/__init__.py
+++ b/fizzbuzz/__init__.py
@@ -1,0 +1,1 @@
+from .fizzbuzz import fizzbuzz

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='fizzbuzz',
-    version='0.0.1',
-    description='Very simple program, often used in software developer job interviews"
-    author='Jennifer Watt',
-    author_email='',
-    url='https://github.com/jekwatt/pytest_playground',
+    name="fizzbuzz",
+    version="0.0.1",
+    description="Very simple program, often used in software developer job interviews",
+    author="Jennifer Watt",
+    author_email="",
+    url="https://github.com/jekwatt/pytest_playground",
     packages=find_packages(exclude=["contrib", "docs", "tests"]),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='fizzbuzz',
+    version='0.0.1',
+    description='Very simple program, often used in software developer job interviews"
+    author='Jennifer Watt',
+    author_email='',
+    url='https://github.com/jekwatt/pytest_playground',
+    packages=find_packages(exclude=["contrib", "docs", "tests"]),
+)

--- a/tests/fizzbuzz/test_fizzbuzz_07_parameters_from_a_file.py
+++ b/tests/fizzbuzz/test_fizzbuzz_07_parameters_from_a_file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from fizzbuzz import fizzbuzz
 
+
 p = Path.cwd()
 FIZZBUZZ_DATA_FILE_NAME = p / "tests" / "fizzbuzz" / "fizzbuzz_data.csv"
 
@@ -14,6 +15,7 @@ def fizzbuzz_cases():
     with open(FIZZBUZZ_DATA_FILE_NAME) as csvfile:
         for value, expected in csv.reader(csvfile):
             yield (int(value), expected)
+
 
 @pytest.mark.parametrize("value, expected", fizzbuzz_cases())
 def test_fizzbuzz(value, expected):


### PR DESCRIPTION
Begin with bare minimum package.  Mainly be able to import setup, find_packages from setuptools, so pytest can find the fizzbuzz libraries.

- Add `fizzbuzz/__init__.py`
- Add `setup.py`